### PR TITLE
[feature] Can change File mode

### DIFF
--- a/example1.py
+++ b/example1.py
@@ -7,12 +7,16 @@ Prints recieved new lines to standard out '''
 
 import tail
 
+FILE_PATH = "./follow_test.txt"
+
 def print_line(txt):
     ''' Prints received text '''
     print(txt)
 
-t = tail.Tail('/var/log/syslog')
-t.register_callback(print_line)
-t.follow(s=5)
+
+if __name__ == "__main__":
+    t = tail.Tail(FILE_PATH)
+    t.register_callback(print_line)
+    t.follow(s=5)
 
 

--- a/follow_test.txt
+++ b/follow_test.txt
@@ -1,0 +1,4 @@
+"Hi EVERY BODY"
+"BYE"
+IMGOODasasdasdasdBYE
+HI안녕하세요

--- a/tail.py
+++ b/tail.py
@@ -36,8 +36,11 @@ class Tail(object):
                 tailed_file - File to be followed. '''
 
         self.check_file_validity(tailed_file)
+
         self.tailed_file = tailed_file
         self.callback = sys.stdout.write
+
+        self._change_other_group_mode()
 
     def follow(self, s=1):
         ''' Do a tail follow. If a callback function is registered it is called with every new line. 
@@ -71,6 +74,16 @@ class Tail(object):
         if os.path.isdir(file_):
             raise TailError("File '%s' is a directory" % (file_))
 
+    def _change_other_group_mode(self):
+        ''' Add write mode in other group that resolve the issue related to #12 '''
+        file_mode = os.stat(self.tailed_file).st_mode
+
+        READ_AND_WRITE = 6
+        file_mode = file_mode | READ_AND_WRITE
+        
+        os.chmod(self.tailed_file, mode=file_mode)
+        print("Change file mode complete")
+        
 class TailError(Exception):
     def __init__(self, msg):
         self.message = msg


### PR DESCRIPTION
```
when i use vim editor to edit file the file follow did not work.
because other group have only read authority the file .
So i  added function that can change file mode for other group in Tail class
```

<strong>The first file mode, it did not run example1.py
![image](https://user-images.githubusercontent.com/30363615/202660284-5a179db9-7a73-47cc-aaf2-612c36ca7d3e.png)

<strong>After run the example.py Like this
![image](https://user-images.githubusercontent.com/30363615/202660610-7a02336f-3bbc-4641-82d9-e64bb33e7d88.png)

<strong>I got new file mode for other group
![image](https://user-images.githubusercontent.com/30363615/202660733-59ab392e-4e78-4866-9b8b-ae3c44a4a91c.png)

##Reuslt
<strong>Can now track files no matter what editor they use.</strong>
![image](https://user-images.githubusercontent.com/30363615/202661153-55f09c8d-800d-4569-bb81-63184e1f73a2.png)


related to [#12](https://github.com/kasun/python-tail/issues/12)